### PR TITLE
Make validation slightly friendlier for humans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Based on mozlz4a.py, which is copyright Tilman Blumenbach and *not* covered by t
 
 Session restore files are created in your Firefox profile directory. You'll want to enable `Open previous windows and tabs` in about:preferences. The primary restore file is `sessionstore.jsonlz4`, and we take snapshots for backup/rollback in the `sessionstore-backups/` sub-directory. 
 
+**Note: this requires the lz4 package which you can install with `pip3 install lz4`**
+
 #### Usage:
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ Session restore files are created in your Firefox profile directory. You'll want
 
 ```
 # To decompress a session restore file
-python3 mozlz4a.py -d --pretty ./previous.jsonlz4 output.json
+python3 mozlz4json.py -d --pretty ./previous.jsonlz4 output.json
 
 # To re-compress a session restore JSON document, ready to copy to a firefox profile directory
-python3 mozlz4a.py -d --pretty ./previous.json sessionstore.jsonlz4
+python3 mozlz4json.py -d --pretty ./previous.json sessionstore.jsonlz4
 
 # NB: output is to stdout unless you provide the output argument, so you can redirect to a file or whatever
 ```
 
 ## `validate.py`
 
-Validate a de-compressed session restore file against a JSON Schema
+Validate a session restore file against a JSON Schema.
+
+**You must decompress the session file to "normal" JSON before validating it.**
 
 #### Usage:
 

--- a/validate.py
+++ b/validate.py
@@ -39,7 +39,11 @@ parsed_args = argparser.parse_args()
 schema = load_json(parsed_args.schema)
 
 # Load JSON document
-json_data = load_json(parsed_args.in_file)
+try:
+    json_data = load_json(parsed_args.in_file)
+except UnicodeDecodeError as ex:
+    print("This file doesn't appear to be JSON; did you un-lz4 the file first?")
+    exit(1)
 
 # Validate the JSON data
 if is_valid_json(json_data, schema):


### PR DESCRIPTION
This updates the instructions so the lz4 script name is correct. It also prints a more human-friendly error if you still end up passing an lz4 file to validate.py